### PR TITLE
Use telnet instead of http

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Calculate diff of an OLSR 0.6.x topology:
     from netdiff import diff
 
     stored = OlsrParser('./stored-olsr.json')
-    latest = OlsrParser('http://127.0.0.1:2006')
+    latest = OlsrParser('http://127.0.0.1:9090')
     diff(stored, latest)
 
 The output will be a dictionary with the following structure:
@@ -94,7 +94,7 @@ Netdiff parsers can return a valid `NetJSON <https://github.com/interop-dev/json
 
     from netdiff import OlsrParser
 
-    olsr = OlsrParser('http://127.0.0.1:2006')
+    olsr = OlsrParser('http://127.0.0.1:9090')
 
     # will return a dict
     olsr.json(dict=True)

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Calculate diff of an OLSR 0.6.x topology:
     from netdiff import diff
 
     stored = OlsrParser('./stored-olsr.json')
-    latest = OlsrParser('http://127.0.0.1:9090')
+    latest = OlsrParser('telnet://127.0.0.1:9090')
     diff(stored, latest)
 
 The output will be a dictionary with the following structure:
@@ -94,7 +94,7 @@ Netdiff parsers can return a valid `NetJSON <https://github.com/interop-dev/json
 
     from netdiff import OlsrParser
 
-    olsr = OlsrParser('http://127.0.0.1:9090')
+    olsr = OlsrParser('telnet://127.0.0.1:9090')
 
     # will return a dict
     olsr.json(dict=True)

--- a/netdiff/parsers/base.py
+++ b/netdiff/parsers/base.py
@@ -1,7 +1,10 @@
 import six
 import json
 import requests
-import urlparse
+try:
+    import urlparse
+except ImportError:
+    import urllib.parse as urlparse
 import telnetlib
 
 from collections import OrderedDict
@@ -63,8 +66,8 @@ class BaseParser(object):
                 telnet_host = up.hostname
                 telnet_port = up.port
                 tn = telnetlib.Telnet(telnet_host, telnet_port)
-                tn.write("\r\n")
-                data = tn.read_all()
+                tn.write(("\r\n").encode('ascii'))
+                data = tn.read_all().decode('ascii')
                 tn.close()
 
             # assuming is JSON

--- a/netdiff/parsers/base.py
+++ b/netdiff/parsers/base.py
@@ -1,6 +1,8 @@
 import six
 import json
 import requests
+import urlparse
+import telnetlib
 
 from collections import OrderedDict
 
@@ -44,6 +46,7 @@ class BaseParser(object):
         Input data might be:
             * a path which points to a JSON file
             * a URL which points to a JSON file
+              (supported schemas: http, https, telnet)
             * a JSON formatted string
             * a dict representing a JSON structure
         """
@@ -55,6 +58,15 @@ class BaseParser(object):
             # if it looks like a URL
             elif data.startswith('http'):
                 data = requests.get(data, verify=False).content.decode()
+            elif data.startswith('telnet'):
+                up = urlparse.urlparse(data)
+                telnet_host = up.hostname
+                telnet_port = up.port
+                tn = telnetlib.Telnet(telnet_host, telnet_port)
+                tn.write("\r\n")
+                data = tn.read_all()
+                tn.close()
+
             # assuming is JSON
             try:
                 return json.loads(data)


### PR DESCRIPTION
According to my tests, olsrd's jsoninfo does not work with http (unlike txtinfo), so I here add support for telnet URIs, which are roughly equivalent to plain TCP sockets.