### PR TITLE
Addedd BMX6 parser using b6m tool to generate the topology.

### DIFF
--- a/netdiff/__init__.py
+++ b/netdiff/__init__.py
@@ -3,4 +3,5 @@ from .info import VERSION, __version__, get_version  # noqa
 from .parsers.olsr import OlsrParser  # noqa
 from .parsers.batman import BatmanParser  # noqa
 from .parsers.netjson import NetJsonParser  # noqa
+from .parsers.bmx6 import Bmx6Parser  # noqa
 from .utils import diff  # noqa

--- a/netdiff/parsers/bmx6.py
+++ b/netdiff/parsers/bmx6.py
@@ -1,0 +1,28 @@
+import networkx
+
+from .base import BaseParser
+from ..exceptions import NetParserException
+
+
+class Bmx6Parser(BaseParser):
+    """ Bmx6_b6m parser """
+    protocol = 'BMX6_b6m'
+    version = '0'
+    metric = 'none'
+
+    def parse(self, data):
+        """
+        Converts a topology in a NetworkX Graph object.
+        """
+        # initialize graph and list of aggregated nodes
+        graph = networkx.Graph()
+        if len(data) != 0:
+            if "links" not in data[0]:
+                raise NetParserException('Parse error, "links" key not found')
+        # loop over topology section and create networkx graph
+        # this topology don't have weight, so we set it as 1
+        for node in data:
+            for neigh in node['links']:
+                if not graph.has_edge(node['name'], neigh['name']):
+                    graph.add_edge(node['name'], neigh['name'], weight=1)
+        self.graph = graph

--- a/tests/bmx6/__init__.py
+++ b/tests/bmx6/__init__.py
@@ -1,0 +1,1 @@
+from .tests import TestBmx6Parser

--- a/tests/bmx6/tests.py
+++ b/tests/bmx6/tests.py
@@ -1,0 +1,88 @@
+import os
+import six
+import networkx
+
+from netdiff import Bmx6Parser
+from netdiff import diff
+from netdiff.tests import TestCase
+from netdiff.exceptions import NetParserException
+
+
+__all__ = ['TestBmx6Parser']
+
+
+CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
+topo = open('{0}/../static/bmx6.json'.format(CURRENT_DIR)).read()
+topo2 = open('{0}/../static/bmx6-1+1.json'.format(CURRENT_DIR)).read()
+
+
+class TestBmx6Parser(TestCase):
+
+    def test_parse(self):
+        p = Bmx6Parser(topo)
+        self.assertIsInstance(p.graph, networkx.Graph)
+
+    def test_parse_exception(self):
+        with self.assertRaises(NetParserException):
+            Bmx6Parser('[{ "test": "test" }]')
+
+    def test_json_dict(self):
+        p = Bmx6Parser(topo)
+        data = p.json(dict=True)
+        self.assertIsInstance(data, dict)
+        self.assertEqual(data['type'], 'NetworkGraph')
+        self.assertEqual(data['protocol'], 'BMX6_b6m')
+        self.assertEqual(data['version'], '0')
+        self.assertEqual(data['metric'], 'none')
+        self.assertIsInstance(data['nodes'], list)
+        self.assertIsInstance(data['links'], list)
+        self.assertEqual(len(data['nodes']), 7)
+        self.assertEqual(len(data['links']), 6)
+
+    def test_json_string(self):
+        p = Bmx6Parser(topo)
+        data = p.json()
+        self.assertIsInstance(data, six.string_types)
+        self.assertIn('NetworkGraph', data)
+        self.assertIn('protocol', data)
+        self.assertIn('version', data)
+        self.assertIn('metric', data)
+        self.assertIn('BMX6_b6m', data)
+        self.assertIn('0', data)
+        self.assertIn('none', data)
+        self.assertIn('links', data)
+        self.assertIn('nodes', data)
+
+    def test_added_removed_1_node(self):
+        old = Bmx6Parser(topo)
+        new = Bmx6Parser(topo2)
+        result = diff(old, new)
+        self.assertTrue(type(result) is dict)
+        self.assertTrue(type(result['added']) is list)
+        self.assertTrue(type(result['removed']) is list)
+        # ensure there are no differences
+        self.assertEqual(len(result['added']), 1)
+        self.assertEqual(len(result['removed']), 1)
+        self._test_expected_links(
+            links=result['added'],
+            expected_links=[
+                ('P9SFCiutatGranada73-68f5', 'P9SFDrTruetaa183-b715')
+            ]
+        )
+        self._test_expected_links(
+            links=result['removed'],
+            expected_links=[
+                ('P9SFCiutatGranada73-68f5', 'P9SFDrTruetaa183-b713')
+            ]
+        )
+
+    def test_no_changes(self):
+        old = Bmx6Parser(topo)
+        new = Bmx6Parser(topo)
+        result = diff(old, new)
+        self.assertTrue(type(result) is dict)
+        self.assertTrue(type(result['added']) is list)
+        self.assertTrue(type(result['removed']) is list)
+        # ensure there are no differences
+        self.assertEqual(len(result['added']), 0)
+        self.assertEqual(len(result['removed']), 0)

--- a/tests/static/bmx6-1+1.json
+++ b/tests/static/bmx6-1+1.json
@@ -1,0 +1,82 @@
+[
+  {
+    "name": "P9SFAlmogavers237-56ac",
+    "links": [
+      {
+        "name": "P9SFBadajoz93-6e99",
+        "rxRate": 91,
+        "txRate": 0
+      },
+      {
+        "name": "P9SFBilbao102-7df9",
+        "rxRate": 97,
+        "txRate": 40
+      },
+      {
+        "name": "P9SFCastanys31-1663",
+        "rxRate": 100,
+        "txRate": 87
+      }
+    ]
+  },
+  {
+      "name": "P9SFBadajoz93-6e99",
+      "links": [
+        {
+          "name": "P9SFAlmogavers237-56ac",
+          "rxRate": 95,
+          "txRate": 1
+        }
+      ]
+  },
+  {
+      "name": "P9SFBilbao102-7df9",
+      "links": [
+        {
+          "name": "P9SFAlmogavers237-56ac",
+          "rxRate": 81,
+          "txRate": 95
+        }
+      ]
+  },
+  {
+      "name": "P9SFCastanys31-1663",
+      "links": [
+        {
+          "name": "P9SFAlmogavers237-56ac",
+          "rxRate": 100,
+          "txRate": 97
+        },
+        {
+          "name": "P9SFCiutatGranada73-68f5",
+          "rxRate": 100,
+          "txRate": 97
+        }
+      ]
+  },
+  {
+      "name": "P9SFCiutatGranada73-68f5",
+      "links": [
+        {
+          "name": "P9SFDrTruetaa183-b715",
+          "rxRate": 93,
+          "txRate": 59
+        },
+        {
+          "name": "PP9SFCastanys31-1663",
+          "rxRate": 93,
+          "txRate": 59
+        }
+      ]
+  },
+  {
+    "name": "P9SFDrTruetaa183-b715",
+    "links": [
+      {
+        "name": "P9SFCiutatGranada73-68f5",
+        "rxRate": 93,
+        "txRate": 59
+      }
+    ]
+  }
+]

--- a/tests/static/bmx6.json
+++ b/tests/static/bmx6.json
@@ -1,0 +1,82 @@
+[
+  {
+    "name": "P9SFAlmogavers237-56ac",
+    "links": [
+      {
+        "name": "P9SFBadajoz93-6e99",
+        "rxRate": 91,
+        "txRate": 0
+      },
+      {
+        "name": "P9SFBilbao102-7df9",
+        "rxRate": 97,
+        "txRate": 40
+      },
+      {
+        "name": "P9SFCastanys31-1663",
+        "rxRate": 100,
+        "txRate": 87
+      }
+    ]
+  },
+  {
+      "name": "P9SFBadajoz93-6e99",
+      "links": [
+        {
+          "name": "P9SFAlmogavers237-56ac",
+          "rxRate": 95,
+          "txRate": 1
+        }
+      ]
+  },
+  {
+      "name": "P9SFBilbao102-7df9",
+      "links": [
+        {
+          "name": "P9SFAlmogavers237-56ac",
+          "rxRate": 81,
+          "txRate": 95
+        }
+      ]
+  },
+  {
+      "name": "P9SFCastanys31-1663",
+      "links": [
+        {
+          "name": "P9SFAlmogavers237-56ac",
+          "rxRate": 100,
+          "txRate": 97
+        },
+        {
+          "name": "P9SFCiutatGranada73-68f5",
+          "rxRate": 100,
+          "txRate": 97
+        }
+      ]
+  },
+  {
+      "name": "P9SFCiutatGranada73-68f5",
+      "links": [
+        {
+          "name": "P9SFDrTruetaa183-b713",
+          "rxRate": 93,
+          "txRate": 59
+        },
+        {
+          "name": "PP9SFCastanys31-1663",
+          "rxRate": 93,
+          "txRate": 59
+        }
+      ]
+  },
+  {
+    "name": "P9SFDrTruetaa183-b713",
+    "links": [
+      {
+        "name": "P9SFCiutatGranada73-68f5",
+        "rxRate": 93,
+        "txRate": 59
+      }
+    ]
+  }
+]


### PR DESCRIPTION
With this parser is possible to parse the topology of a BMX6 network.
The tool [b6m](http://dev.qmp.cat/projects/b6m) generate the topology of the BMX6 network as a JSON. 