### PR TITLE
use the substraction overloaded operator to call the diff between parsers/topologies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,17 @@ The output will be a dictionary with the following structure:
         "removed": []
     }
 
+In alternative, you can use the subtraction operator:
+
+.. code-block:: python
+
+    from netdiff import OlsrParser
+    from netdiff import diff
+
+    stored = OlsrParser('./stored-olsr.json')
+    latest = OlsrParser('telnet://127.0.0.1:9090')
+    latest - stored
+
 Parsers
 -------
 

--- a/netdiff/parsers/base.py
+++ b/netdiff/parsers/base.py
@@ -11,6 +11,7 @@ except ImportError:
     import urllib.parse as urlparse
 
 from ..exceptions import NetParserException, NetParserJsonException, NetJsonException
+from ..utils import diff
 
 
 class BaseParser(object):
@@ -43,6 +44,9 @@ class BaseParser(object):
         # avoid throwing NotImplementedError in tests
         if self.__class__ is not BaseParser:
             self.parse(self.original_data)
+
+    def __sub__(self, other):
+        return diff(other, self)
 
     def _to_python(self, data):
         """

--- a/tests/olsr/tests.py
+++ b/tests/olsr/tests.py
@@ -91,6 +91,17 @@ class TestOlsrParser(TestCase):
         self.assertIn('10.150.0.5', result['added'][0])
         self.assertIn('10.150.0.4', result['added'][0])
 
+    def test_added_1_link_sub(self):
+        old = OlsrParser(links2)
+        new = OlsrParser(links3)
+        result = new - old
+        # ensure there are differences
+        self.assertEqual(len(result['added']), 1)
+        self.assertEqual(len(result['removed']), 0)
+        # ensure 1 link added
+        self.assertIn('10.150.0.5', result['added'][0])
+        self.assertIn('10.150.0.4', result['added'][0])
+
     def test_removed_1_link(self):
         old = OlsrParser(links3)
         new = OlsrParser(links2)


### PR DESCRIPTION
Example usage:
```
>>> from netdiff import OlsrParser
>>> url = 'telnet://127.0.0.1:9090/'
>>> p = OlsrParser(url)
>>> q = OlsrParser(url)
>>> p - q
{'removed': [], 'added': []}
```
