### PR TITLE
Implemented stricter input (backward incompatible)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,8 +81,8 @@ Calculate diff of an OLSR 0.6.x topology:
     from netdiff import OlsrParser
     from netdiff import diff
 
-    old = OlsrParser('./stored-olsr.json')
-    new = OlsrParser('http://127.0.0.1:9090')
+    old = OlsrParser(file='./stored-olsr.json')
+    new = OlsrParser(url='http://127.0.0.1:9090')
     diff(old, new)
 
 In alternative, you may also use the subtraction operator:
@@ -92,8 +92,8 @@ In alternative, you may also use the subtraction operator:
     from netdiff import OlsrParser
     from netdiff import diff
 
-    old = OlsrParser('./stored-olsr.json')
-    new = OlsrParser('http://127.0.0.1:9090')
+    old = OlsrParser(file='./stored-olsr.json')
+    new = OlsrParser(url='http://127.0.0.1:9090')
     old - new
 
 The output will be an ordered dictionary with three keys:
@@ -210,18 +210,17 @@ The available parsers are:
 Initialization arguments
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-**data**: the only required argument, different inputs are accepted:
+Data can be supplied in 3 different ways, in the following order of precedence:
 
-* JSON formatted string representing the topology
-* python `dict` (or subclass of `dict`) representing the topology
-* string representing a HTTP URL where the data resides
-* string representing a telnet URL where the data resides
-* string representing a file path where the data resides
+* ``data``: ``dict`` or ``str`` representing the topology/graph
+* ``url``: URL to fetch data from
+* ``file``: file path to retrieve data from
 
-**timeout**: integer representing timeout in seconds for HTTP or telnet requests, defaults to None
+Other available arguments:
 
-**verify**: boolean indicating to the `request library whether to do SSL certificate
-verification or not <http://docs.python-requests.org/en/latest/user/advanced/#ssl-cert-verification>`_
+* **timeout**: integer representing timeout in seconds for HTTP or telnet requests, defaults to ``None``
+* **verify**: boolean indicating to the `request library whether to do SSL certificate
+  verification or not <http://docs.python-requests.org/en/latest/user/advanced/#ssl-cert-verification>`_
 
 Initialization examples
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -231,7 +230,7 @@ Local file example:
 .. code-block:: python
 
     from netdiff import BatmanParser
-    BatmanParser('./my-stored-topology.json')
+    BatmanParser(file='./my-stored-topology.json')
 
 HTTP example:
 
@@ -239,33 +238,32 @@ HTTP example:
 
     from netdiff import NetJsonParser
     url = 'https://raw.githubusercontent.com/interop-dev/netjson/master/examples/network-graph.json'
-    NetJsonParser(url)
+    NetJsonParser(url=url)
 
 Telnet example with ``timeout``:
 
 .. code-block:: python
 
     from netdiff import OlsrParser
-    OlsrParser('telnet://127.0.1:8080', timeout=5)
+    OlsrParser(url='telnet://127.0.1', timeout=5)
 
 HTTPS example with self-signed SSL certificate using ``verify=False``:
 
 .. code-block:: python
 
     from netdiff import NetJsonParser
-    OlsrParser('https://myserver.mydomain.com/topology.json', verify=False)
+    OlsrParser(url='https://myserver.mydomain.com/topology.json', verify=False)
 
 NetJSON output
 --------------
 
-Netdiff parsers can return a valid `NetJSON`_
-``NetworkGraph`` object:
+Netdiff parsers can return a valid `NetJSON`_ ``NetworkGraph`` object:
 
 .. code-block:: python
 
     from netdiff import OlsrParser
 
-    olsr = OlsrParser('telnet://127.0.0.1:9090')
+    olsr = OlsrParser(url='telnet://127.0.0.1:9090')
 
     # will return a dict
     olsr.json(dict=True)

--- a/tests/test_netjson.py
+++ b/tests/test_netjson.py
@@ -9,8 +9,8 @@ from netdiff.tests import TestCase
 
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
-links2 = '{0}/static/netjson-2-links.json'.format(CURRENT_DIR)
-links3 = '{0}/static/netjson-3-links.json'.format(CURRENT_DIR)
+links2 = open('{0}/static/netjson-2-links.json'.format(CURRENT_DIR)).read()
+links3 = open('{0}/static/netjson-3-links.json'.format(CURRENT_DIR)).read()
 
 
 class TestNetJsonParser(TestCase):

--- a/tests/test_olsr.py
+++ b/tests/test_olsr.py
@@ -9,11 +9,11 @@ from netdiff.tests import TestCase
 
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
-links2 = '{0}/static/olsr-2-links.json'.format(CURRENT_DIR)
-links2_cost = '{0}/static/olsr-2-links-cost-changed.json'.format(CURRENT_DIR)
-links3 = '{0}/static/olsr-3-links.json'.format(CURRENT_DIR)
-links5 = '{0}/static/olsr-5-links.json'.format(CURRENT_DIR)
-links5_cost = '{0}/static/olsr-5-links-cost-changed.json'.format(CURRENT_DIR)
+links2 = open('{0}/static/olsr-2-links.json'.format(CURRENT_DIR)).read()
+links2_cost = open('{0}/static/olsr-2-links-cost-changed.json'.format(CURRENT_DIR)).read()
+links3 = open('{0}/static/olsr-3-links.json'.format(CURRENT_DIR)).read()
+links5 = open('{0}/static/olsr-5-links.json'.format(CURRENT_DIR)).read()
+links5_cost = open('{0}/static/olsr-5-links-cost-changed.json'.format(CURRENT_DIR)).read()
 
 
 class TestOlsrParser(TestCase):

--- a/tests/test_olsr_txtinfo.py
+++ b/tests/test_olsr_txtinfo.py
@@ -9,10 +9,10 @@ from netdiff.tests import TestCase
 
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
-links2 = '{0}/static/olsr-2-links.txt'.format(CURRENT_DIR)
-links2_cost = '{0}/static/olsr-2-links-cost-changed.txt'.format(CURRENT_DIR)
-links3 = '{0}/static/olsr-3-links.txt'.format(CURRENT_DIR)
-links5 = '{0}/static/olsr-5-links.txt'.format(CURRENT_DIR)
+links2 = open('{0}/static/olsr-2-links.txt'.format(CURRENT_DIR)).read()
+links2_cost = open('{0}/static/olsr-2-links-cost-changed.txt'.format(CURRENT_DIR)).read()
+links3 = open('{0}/static/olsr-3-links.txt'.format(CURRENT_DIR)).read()
+links5 = open('{0}/static/olsr-5-links.txt'.format(CURRENT_DIR)).read()
 
 
 class TestOlsrTxtinfoParser(TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ from netdiff.tests import TestCase
 
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
-links2 = '{0}/static/netjson-2-links.json'.format(CURRENT_DIR)
+links2 = open('{0}/static/netjson-2-links.json'.format(CURRENT_DIR)).read()
 
 
 class TestUtils(TestCase):


### PR DESCRIPTION
Whether network graph data is passed directly or fetched from a URL or a file should be explicit in order to avoid opening security holes in the system.

References and closes #40 