### PR TITLE
add flake8 to travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ install:
   - python setup.py -q develop
   - pip install -r requirements-test.txt
 
+# command to run flake8
+before_script: "flake8 netdiff"
+
 # command to run tests, e.g. python setup.py test
 script:
   - nosetests --with-coverage --cover-package=netdiff

--- a/netdiff/__init__.py
+++ b/netdiff/__init__.py
@@ -5,5 +5,5 @@ from .parsers.batman import BatmanParser  # noqa
 from .parsers.bmx6 import Bmx6Parser  # noqa
 from .parsers.netjson import NetJsonParser  # noqa
 from .parsers.cnml import CnmlParser  # noqa
-from .parsers.openvpn import OpenvpnParser #noqa
+from .parsers.openvpn import OpenvpnParser  # noqa
 from .utils import diff  # noqa

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,4 @@ coverage
 coveralls
 responses>0.5.0,<0.8.0
 mock
+flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal=1
+
+[flake8]
+max-line-length = 110


### PR DESCRIPTION
This ensures that we test for pep8 compliance during Travis instead of self-enforcing.